### PR TITLE
returning gtable object rather than just drawing in device

### DIFF
--- a/R/grid_arrange_shared_legend.R
+++ b/R/grid_arrange_shared_legend.R
@@ -37,4 +37,5 @@ grid_arrange_shared_legend <- function(plots, ncol = length(plots), nrow = 1,
     }
     grid::grid.newpage()
     grid::grid.draw(combined)
+    invisible(combined)
 }

--- a/R/plot.cutpointr.R
+++ b/R/plot.cutpointr.R
@@ -106,7 +106,8 @@ plot.cutpointr <- function(x, ...) {
     plots <- lapply(plots, function(p) p + args)
     rows <- round(sum(keep) / 2)
     pos <- ifelse(rows > 1, "right", "bottom")
-    suppressMessages(grid_arrange_shared_legend(plots,
+    suppressMessages(p <- grid_arrange_shared_legend(plots,
                                                 nrow = rows, ncol = 2,
                                                 position = pos))
+    invisible(p)
 }


### PR DESCRIPTION
changes in plot.cutpointr and grid_arrange_shared_legend. plot.cutpointr now also returns an gtable object which makes it possible to store it in an r-object and can be saved by using ggsave instead of just drawing the plot to the device