### PR TITLE
Update of pROC 1.15

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1041,7 +1041,7 @@ rocr_sensspec <- function(x, class) {
 # pROC package
 proc_sensspec <- function(x, class) {
     r <- pROC::roc(class, x, algorithm = 2, levels = c(0, 1), direction = "<")
-    pROC::coords(r, "best", ret="threshold")[1]
+    pROC::coords(r, "best", ret="threshold", transpose = FALSE)[1]
 }
 ```
 

--- a/vignettes/cutpointr.Rmd
+++ b/vignettes/cutpointr.Rmd
@@ -1033,7 +1033,7 @@ rocr_sensspec <- function(x, class) {
 # pROC package
 proc_sensspec <- function(x, class) {
     r <- pROC::roc(class, x, algorithm = 2, levels = c(0, 1), direction = "<")
-    pROC::coords(r, "best", ret="threshold")[1]
+    pROC::coords(r, "best", ret="threshold", transpose = FALSE)[1]
 }
 ```
 


### PR DESCRIPTION
Version 1.15 of pROC is now on CRAN with the latest speed improvements.

There has been one more change in this version with an extra `transpose` argument that is now recommended with `coords`, the only change in this PR. I found it made no significant difference in the benchmark, so left the data unchanged.